### PR TITLE
Overlay follows trigger movement

### DIFF
--- a/unify/framework/source/class/unify/ui/container/Overlay.js
+++ b/unify/framework/source/class/unify/ui/container/Overlay.js
@@ -280,6 +280,10 @@ qx.Class.define("unify.ui.container.Overlay", {
       var posHint = this.__getPositionHint();
       this.getLayoutParent().add(this, posHint);
       this.fireEvent("shown");
+      var trigger=this.getTrigger();
+      if(trigger){
+        trigger.addListener("move",this.__onTriggerMove,this);
+      }
     },
     
     /**
@@ -288,6 +292,24 @@ qx.Class.define("unify.ui.container.Overlay", {
     hide : function() {
       this.base(arguments);
       this.fireEvent("hidden");
+      var trigger=this.getTrigger();
+      if(trigger){
+        trigger.removeListener("move",this.__onTriggerMove,this);
+      }
+    },
+
+    /**
+     * event handler for trigger move event.
+     * 
+     * repositions the overlay to the new trigger position if the overlay is visible
+     * 
+     * @param e {Event} event object
+     */
+    __onTriggerMove: function(e){
+      if(this.isVisible()){
+        var posHint = this.__getPositionHint();
+        this.getLayoutParent().add(this, posHint);
+      }
     }
   }
 });


### PR DESCRIPTION
a button that triggers an overlay may change it's position while the overlay is visible (e.g. due to an orientation change of the display, newly added content etc.)

If the overlay has a configured relative position to it's trigger, it should maintain this position even when the triger moves.

This pull request does just that by listening to the triggers move event while Overlay is visible
