### PR TITLE
when navigating to the same view, don't create another path entry (implicit rel=same)

### DIFF
--- a/unify/framework/source/class/unify/ui/core/MNavigatable.js
+++ b/unify/framework/source/class/unify/ui/core/MNavigatable.js
@@ -115,7 +115,7 @@ qx.Mixin.define("unify.ui.core.MNavigatable", {
           this.warn("Widget " + this + " has no parent view manager!");
         }
       }
-      
+
       var exec = this.getExecute();
       if (exec) {
         viewManager.getCurrentView()[exec](this);
@@ -128,10 +128,12 @@ qx.Mixin.define("unify.ui.core.MNavigatable", {
           } else {
             window.location = href;
           }
-        } else if (!this.__navigates) {
-          // Lazily navigate (omits navigation during activity)
-          this.__navigates = true;
-          qx.lang.Function.delay(this.__navigationWidgetHelper, 0, this, viewManager);
+        } else if (!viewManager.isInAnimation()) {
+          this.__navigationWidgetHelper(viewManager);
+        } else {
+          if(qx.core.Environment.get("qx.debug")){
+            this.debug(viewManager.getId()+ "is currently animating, skipping navigation attempt");
+          }
         }
       }
     },
@@ -238,7 +240,7 @@ qx.Mixin.define("unify.ui.core.MNavigatable", {
         var cloneLast = clone.length-1;
         
         // Select right modification point
-        if (rel == "same" || clone[cloneLast].view===config.view) 
+        if (rel == "same") 
         {
           clone[cloneLast] = config;
         } 

--- a/unify/framework/source/class/unify/ui/core/MNavigatable.js
+++ b/unify/framework/source/class/unify/ui/core/MNavigatable.js
@@ -238,7 +238,7 @@ qx.Mixin.define("unify.ui.core.MNavigatable", {
         var cloneLast = clone.length-1;
         
         // Select right modification point
-        if (rel == "same") 
+        if (rel == "same" || clone[cloneLast].view===config.view) 
         {
           clone[cloneLast] = config;
         } 

--- a/unify/framework/source/class/unify/view/ViewManager.js
+++ b/unify/framework/source/class/unify/view/ViewManager.js
@@ -184,6 +184,14 @@ qx.Class.define("unify.view.ViewManager", {
   members :
   {
     __initialized : false,
+    __isInAnimation: false,
+
+    /**
+     * @return {Boolean} true if this ViewManager currently animates the transition between 2 views
+     */
+    isInAnimation: function(){
+      return this.__isInAnimation;
+    },
     
     /**
      * Returns the currently selected view instance
@@ -304,7 +312,7 @@ qx.Class.define("unify.view.ViewManager", {
         this.warn("Empty path!");
         return;
       }
-      
+
       var oldPath = this.__path;
       var oldLength = oldPath ? oldPath.length : 0;
       var layerTransition = null;
@@ -663,6 +671,7 @@ qx.Class.define("unify.view.ViewManager", {
      */
     __setView : function(view, transition)
     {
+      
       // TODO: view.getElement() is also called if view is in popover
       //       Maybe it should be rendered lazy
       var oldView = this.__currentView;
@@ -680,13 +689,10 @@ qx.Class.define("unify.view.ViewManager", {
 
       // Resuming the view
       view.setActive(true);
-
-      // Cache element/view references
-      var currentViewElement = view;// && view.getElement();
-      var oldViewElement = oldView;// && oldView.getElement();
+      
 
       // Insert target layer into DOM
-      if (this.indexOf(view) == -1 /*true || currentViewElement.parentNode != elem*/) {
+      if (this.indexOf(view) == -1) {
         this.add(view, {
           left: 0,
           top: 0,
@@ -695,8 +701,6 @@ qx.Class.define("unify.view.ViewManager", {
         });
       }
 
-      // Transition specific layer switch
-      var positions = this.__positions;
 
       if (this.getAnimateTransitions() &&(transition == "in" || transition == "out"))
       {
@@ -736,8 +740,10 @@ qx.Class.define("unify.view.ViewManager", {
 
       var visibilityAction = function() {
         var afterRenderAction = function() {
+          self.__isInAnimation=true;
           var transitionEndFnt = function() {
             fromView.setVisibility("hidden");
+            self.__isInAnimation=false;
           };
           fromView.addListenerOnce("animatePositionDone", transitionEndFnt, this);
           
@@ -790,10 +796,12 @@ qx.Class.define("unify.view.ViewManager", {
 
       var visibilityAction = function() {
         var afterRenderAction = function() {
+          self.__isInAnimation=true;
           var transitionEndFnt = function() {if(!show){
             view.setActive(false);
             view.hide();
             self.hide();
+            self.__isInAnimation=false;
           }
             if(callback){
               callback();


### PR DESCRIPTION
Viewmanagers don't allow navigating to the view they are already showing (they throw an error if you do).
If you implement a view, that contains MNavigatables with goto to open a new view layer and a user double taps on such an MNavigatable, the first tap navigates the viewmanager to the target view and the second tries to do it again, causing an error (parent view class could not be identical to current view class)

to prevent this from happening (and allow for the case that a navigation action only changes a param or a segment but not the view), i changed MNavigatable to treat navigation attempts to the same view like rel=same was set.
