### PR TITLE
Fix/navigationinit

### DIFF
--- a/unify/framework/source/class/unify/view/Navigation.js
+++ b/unify/framework/source/class/unify/view/Navigation.js
@@ -91,7 +91,7 @@ qx.Class.define("unify.view.Navigation",
       History.addListener("change", this.__onHistoryChange, this);
 
       // Restore path from storage or use default view
-      var path = unify.bom.Storage.get("navigation-path");
+      var path = unify.bom.Storage.get("navigation-path")||"";
       var pathObj=unify.view.Path.fromString(path);
       if(!this.isValidNavigationPath(pathObj)){
         if(qx.core.Environment.get("qx.debug")){


### PR DESCRIPTION
fixes a bug in the latest navigation code. If no navigation-path was set in localstorage, path was null and caused an error. In case no path is found in storage, an empty path is used now (which results in the application starting with the default path).
