### PR TITLE
changed unify.ui.basic.Label html property to false and added _applyHtml...

### DIFF
--- a/unify/framework/source/class/unify/ui/basic/Label.js
+++ b/unify/framework/source/class/unify/ui/basic/Label.js
@@ -56,8 +56,9 @@ qx.Class.define("unify.ui.basic.Label", {
     /** Wheter the content is HTML or plain text */
     html : {
       check: "Boolean",
-      init: true,
-      event: "changeHtml"
+      init: false,
+      event: "changeHtml",
+      apply:"_applyHtml"
     },
 
     // overridden
@@ -225,6 +226,24 @@ qx.Class.define("unify.ui.basic.Label", {
         this.addState("wrap");
       } else {
         this.removeState("wrap");
+      }
+    },
+
+    /**
+     * executed on change of the html property
+     * 
+     * reapplies element value if the element was already created
+     * to maintain internal consistency
+     * 
+     * @param value {Boolean} new value
+     */
+    _applyHtml: function(value){
+      var elem=this.getElement();
+      if(elem){
+        var val=this.getValue(); //cache 
+        this._applyValue("");    //unset 
+        elem.useHtml=!!value;    //change qooxdoo interhal flag (see qx.bom.Label)
+        this._applyValue(val);   //apply cached 
       }
     }
   }


### PR DESCRIPTION
... to keep internal state consistent when html property changes its value. This change means that Label values are not interpreted by default.
