### PR TITLE
logic and performance fixes for pull-to-refresh

### DIFF
--- a/unify/framework/source/class/unify/bom/Transform.js
+++ b/unify/framework/source/class/unify/bom/Transform.js
@@ -67,6 +67,31 @@ qx.Class.define("unify.bom.Transform",
      */
     scale : function (x,y){
       return "scale("+x+","+y+")";
+    },
+    
+    /**
+     * Generates rotate string to have accelerated rotate (if supported)
+     *
+     * @param deg {Integer} deg value to rotate to
+     * @return {String} Accelerated rotate
+     */
+    accelRotate : function(deg){
+      // Fix resize bug with translate3d on google chrome 15.0.874.121 m
+      if (qx.core.Environment.get("browser.name") == "chrome" || qx.core.Environment.get("engine.name") != "webkit") {
+        return "rotate("+deg+"deg)";
+      } else {
+        return "rotate3d(0,0,1,"+deg+"deg)";
+      }
+    },
+
+    /**
+     * Generates rotate string
+     *
+     * @param deg {Integer} deg  value to rotate to
+     * @return {String} rotate
+     */
+    rotate : function (deg){
+      return "rotate("+deg+"deg)";
     }
   }
 });

--- a/unify/framework/source/class/unify/fx/core/Animation.js
+++ b/unify/framework/source/class/unify/fx/core/Animation.js
@@ -81,10 +81,16 @@ qx.Class.define("unify.fx.core.Animation", {
       // Compacting running db automatically every few new animations
       if (id % 20 === 0) {
         var newRunning = {};
+        var newPercent = {};
+        var currentPercent=this.__percent;
         for (var usedId in running) {
-          newRunning[usedId] = true;
+          if(running[usedId]){
+            newRunning[usedId] = true;
+            newPercent[usedId] = currentPercent[usedId];
+          }
         }
-        running = newRunning;
+        running = this.__running = newRunning;
+        this.__percent = newPercent;
       }
 
       // This is the internal step method which is called every few milliseconds
@@ -122,7 +128,7 @@ qx.Class.define("unify.fx.core.Animation", {
         if (duration) {
           percent = self.__percent[id] = (now - start) / duration + startPosition;
           if (percent > 1) {
-            percent = 1;
+            percent = self.__percent[id] = 1;
           }
         }
         if(repeat && percent==1){

--- a/unify/framework/source/class/unify/theme/dark/Appearance.js
+++ b/unify/framework/source/class/unify/theme/dark/Appearance.js
@@ -905,25 +905,23 @@ qx.Theme.define("unify.theme.dark.Appearance", {
     "scroll/topNotification/label":{
       include:"label"
     },
+    "scroll/topNotification/iconcontainer":{},
     "scroll/topNotification/pullicon":{
-      //TODO: add default icons for states initial, activated and executing   
-      //sugestion:
-      // use transition animation rotate(-180) for changing arrow direction on initial/activating
+      //TODO: add default icons 
     },
     "scroll/topNotification/activityicon":{
-      //TODO: add default icons for states initial, activated and executing   
-      //sugestion:
-      // use keyframe animation with infinite rotation (see KeframeAnimatedImage for example)
+      //TODO: add default icons 
     },
     "scroll/bottomNotification":{},
     "scroll/bottomNotification/label":{
       include:"label"
     },
+    "scroll/bottomNotification/iconcontainer":{},
     "scroll/bottomNotification/pullicon":{
-      //TODO: add default icons for states initial, activated and executing
+      //TODO: add default icons 
     },
     "scroll/bottomNotification/activityicon":{
-      //TODO: add default icons for states initial, activated and executing
+      //TODO: add default icons 
     }
   }
 });

--- a/unify/framework/source/class/unify/ui/container/Scroll.js
+++ b/unify/framework/source/class/unify/ui/container/Scroll.js
@@ -54,6 +54,10 @@ qx.Class.define("unify.ui.container.Scroll", {
     contentWidget.addListener("resize", this.__updateDimensions, this);
     
     this.addListener("changeVisibility", this.__onChangeVisibility, this);
+    var root = qx.core.Init.getApplication().getRoot();
+    root.addListener("touchmove", this.__onTouchMove,this);
+    root.addListener("touchend", this.__onTouchEnd,this);
+    root.addListener("touchcancel", this.__onTouchEnd,this);
   },
 
   /*
@@ -162,6 +166,7 @@ qx.Class.define("unify.ui.container.Scroll", {
     __horizontalScrollIndicator : null,
     
     __inTouch : false,
+    __showIndicatorsOnNextTouchMove: false,
 
     /*
      ---------------------------------------------------------------------------
@@ -644,6 +649,7 @@ qx.Class.define("unify.ui.container.Scroll", {
      */
     __onTouchStart : function(e){
       this.__inTouch = true;
+      this.__showIndicatorsOnNextTouchMove=true;
       //TODO why is this called here? touchstart should not change the properties, so no need to recache them
       this.__updateProperties();
 
@@ -662,12 +668,6 @@ qx.Class.define("unify.ui.container.Scroll", {
 
       this.__scroller.doTouchStart(touches, +ne.timeStamp);
       e.preventDefault();
-      this.addListenerOnce("touchmove",this.__showIndicators,this);
-      
-      var root = qx.core.Init.getApplication().getRoot();
-      root.addListener("touchmove", this.__onTouchMove,this);
-      root.addListener("touchend", this.__onTouchEnd,this);
-      root.addListener("touchcancel", this.__onTouchEnd,this);
     },
 
     /**
@@ -690,6 +690,14 @@ qx.Class.define("unify.ui.container.Scroll", {
      * @param e {qx.event.type.Touch} Touch event
      */
     __onTouchMove : function(e){
+      if(!this.__inTouch){
+        return;
+      }
+      if(this.__showIndicatorsOnNextTouchMove){
+        this.__showIndicatorsOnNextTouchMove=false;
+        this.__showIndicators();
+        
+      }
       var ne=e.getNativeEvent();
       this.__scroller.doTouchMove(ne.touches, +ne.timeStamp, ne.scale);
     },
@@ -700,13 +708,12 @@ qx.Class.define("unify.ui.container.Scroll", {
      * @param e {qx.event.type.Touch} Touch event
      */
     __onTouchEnd : function(e){
+      if(!this.__inTouch){
+        return;
+      }
       this.__inTouch = false;
+      this.__showIndicatorsOnNextTouchMove=false;
       this.__scroller.doTouchEnd(+e.getNativeEvent().timeStamp);
-      
-      var root = qx.core.Init.getApplication().getRoot();
-      root.removeListener("touchmove", this.__onTouchMove,this);
-      root.removeListener("touchend", this.__onTouchEnd,this);
-      root.removeListener("touchcancel", this.__onTouchEnd,this);
     },
     
     /**
@@ -736,6 +743,10 @@ qx.Class.define("unify.ui.container.Scroll", {
     this.removeListener("resize", this.__updateDimensions, this);
     this.getChildrenContainer().removeListener("resize", this.__updateDimensions, this);
     this.removeListener("changeVisibility", this.__onChangeVisibility, this);
+    var root = qx.core.Init.getApplication().getRoot();
+    root.removeListener("touchmove", this.__onTouchMove,this);
+    root.removeListener("touchend", this.__onTouchEnd,this);
+    root.removeListener("touchcancel", this.__onTouchEnd,this);
   }
 });
 


### PR DESCRIPTION
1. changed Scroll to not register/unregister event handlers on touchstart/touchend. It may be possible that touchend does not occur and that would cause multiple registrations
2. ActionScroll doesn't change notifications or execute actions whhile an action is being executed
3. ActionScroll uses an additional container to box icons to prevent layout changes on phase change
4. ActionScroll does not use state changes for icons anymore. Instead it manipulates dom element styles directly to ensure the correct styles are applied when needed
5. fixed Animation to actually cleanup internal cache
