### PR TITLE
Fix/requestheader

### DIFF
--- a/unify/framework/source/class/unify/business/RemoteData.js
+++ b/unify/framework/source/class/unify/business/RemoteData.js
@@ -560,7 +560,7 @@ core.Class("unify.business.RemoteData",
     setRequestHeader : function(name, value) {
       this.__headers[name] = value;
       
-      if(!value){ //if no value is supplied, we delete the request header from the map
+      if(value === null){ //if no value is supplied, we delete the request header from the map
         delete this.__headers[name];
       }
     },

--- a/unify/framework/source/class/unify/business/RemoteData.js
+++ b/unify/framework/source/class/unify/business/RemoteData.js
@@ -559,6 +559,10 @@ core.Class("unify.business.RemoteData",
      */
     setRequestHeader : function(name, value) {
       this.__headers[name] = value;
+      
+      if(!value){ //if no value is supplied, we delete the request header from the map
+        delete this.__headers[name];
+      }
     },
 
     /**
@@ -619,7 +623,7 @@ core.Class("unify.business.RemoteData",
             requestHeaders["If-Modified-Since"] = cacheModified;
           } else {
             unify.business.SyncRegistry.clear(url);
-            requestHeaders["If-Modified-Since"] = "Thu, 01 Jan 1970 00:00:00 GMT"
+            requestHeaders["If-Modified-Since"] = "Thu, 01 Jan 1970 00:00:00 GMT";
           }
         }
       }


### PR DESCRIPTION
Added the possibility to remove a request header from the request header map by setting the value to null.
Example : this.setRequestHeader("If-Modified-Since", null);

This is useful if you have more than one service defined in your remoteData implementation and those need different request headers.
