### PR TITLE
Fixed default button for dialogs

### DIFF
--- a/unify/framework/source/class/unify/ui/dialog/GenericDialog.js
+++ b/unify/framework/source/class/unify/ui/dialog/GenericDialog.js
@@ -216,6 +216,8 @@
           okBtn.addListener("execute", function() {
             this.fireEvent("execute", BTN_OK);
           }, this);
+
+          centerButtonContainer.add(okBtn);
         } else { // buttons.length > 0  
           var btnCount = buttons.length;
           


### PR DESCRIPTION
If no configuration for buttons was passed while creating a dialog, the default OK button was not added to the dialog, thus leaving no obvious way to close the dialog (except from the little x in the top right hand corner of the dialog).
