### PR TITLE
Improve UI responsiveness for blocker elements

### DIFF
--- a/unify/framework/source/class/unify/ui/core/PopOverManager.js
+++ b/unify/framework/source/class/unify/ui/core/PopOverManager.js
@@ -52,10 +52,15 @@ core.Class("unify.ui.core.PopOverManager", {
     mblocker.id = "modal-blocker";
     
     this.addNativeListener(pblocker, "tap", this.__onTapBlocker, this);
-    
-    var rootElement = root.getViewportElement();
-    rootElement.appendChild(pblocker);
-    rootElement.appendChild(mblocker);
+
+    // Give the browser some time to do stuff to be ready to insert the
+    // blocker elements. This way, the UI seems much more responsive,
+    // especially on 'slow' devices, e.g. iPad
+    (function fn() {
+      var rootElement = root.getViewportElement();
+      rootElement.appendChild(pblocker);
+      rootElement.appendChild(mblocker);
+    }.lowDelay(0));
   },
   
   events : {

--- a/unify/framework/source/class/unify/ui/core/PopOverManager.js
+++ b/unify/framework/source/class/unify/ui/core/PopOverManager.js
@@ -60,7 +60,7 @@ core.Class("unify.ui.core.PopOverManager", {
       var rootElement = root.getViewportElement();
       rootElement.appendChild(pblocker);
       rootElement.appendChild(mblocker);
-    }.lowDelay(0));
+    }.lazy());
   },
   
   events : {


### PR DESCRIPTION
Especially on slow devices, the browser sometimes is "not strong enough" to handle DOM changes, rendering and JavaScript execution (among other things) at the same time. Therefore, the blocker element does not show the waiting animation, just a colored square. By giving the browser some time to do stuff, UI seems much more responsive to the user.
