### PR TITLE
Simulate onInput for IE < 8

### DIFF
--- a/unify/framework/source/class/unify/ui/form/TextField.js
+++ b/unify/framework/source/class/unify/ui/form/TextField.js
@@ -118,7 +118,15 @@ core.Class("unify.ui.form.TextField", {
       if (type == "number") {
         e.setAttribute("pattern", "[0-9]*");
       }
-      this.addNativeListener(e, "input", this._onInput, this);
+
+      if (core.Env.getValue('engine') == 'trident') {
+        // IE < 8 does not support oninput event, so we listen to
+        // onkeyup instead (for now, in every IE version)
+        this.addNativeListener(e, "keyup", this._onInput, this);
+      } else {
+        this.addNativeListener(e, "input", this._onInput, this);
+      }
+
 
       return e;
     },


### PR DESCRIPTION
Since oninput event is not supported in IE < 8, we listen to onkeyup instead
