### PR TITLE
Fix IE init application

### DIFF
--- a/unify/framework/source/class/unify/core/Init.js
+++ b/unify/framework/source/class/unify/core/Init.js
@@ -18,11 +18,19 @@
    *                   false: otherwise
    */
   var isDocReady = function() {
-    if (document.readyState === 'interactive' || document.readyState === 'complete') {
-      return true;
+    var isReady = false;
+
+    if (core.Env.getValue('engine') === 'trident') {
+      if (document.readyState === 'complete') {
+        isReady = true;
+      }
+    } else {
+      if (document.readyState === 'interactive' || document.readyState === 'complete') {
+        isReady = true;
+      }
     }
 
-    return false;
+    return isReady;
   };
 
 


### PR DESCRIPTION
For some unknown reason, IE sometimes does not initialize an unify app when the document's readyState is 'interactive'. For now, the app is only initialized when the readyState is 'complete' on IE. (probably, this needs further investigation)
