### PR TITLE
Make use of HTML5 placeholder attribute for text area, if applicable

### DIFF
--- a/unify/framework/source/class/unify/ui/form/TextArea.js
+++ b/unify/framework/source/class/unify/ui/form/TextArea.js
@@ -86,8 +86,13 @@ core.Class("unify.ui.form.TextArea", {
 		 * Apply placeholder value
 		 */
 		_applyPlaceholderValue: function(placeholder) {
-			this.__placeholderValue = placeholder;
-			this.__onBlur();
+      if (jasy.Env.isSet("html5.placeholder")) {
+        var e = this.getElement();
+        e.setAttribute("placeholder", placeholder);
+      } else {
+        this.__placeholderValue = placeholder;
+        this.__onBlur();
+      }
 		},
 		
 		/**


### PR DESCRIPTION
If the browser supports the HTML5 placeholder attribute for text area elements, we make use of it from now on
