### PR TITLE
added new interface for popovermanager; Expanded popovermanager to support 3 types of popups

### DIFF
--- a/unify/framework/source/class/unify/ui/core/IPopUp.js
+++ b/unify/framework/source/class/unify/ui/core/IPopUp.js
@@ -1,0 +1,30 @@
+/*
+===============================================================================================
+
+		Unify Project
+
+		Homepage: unify-project.org
+		License: MIT + Apache (V2)
+		Copyright: 2013 Sebastian Fastner, Mainz, Germany, http://unify-training.com
+
+===============================================================================================
+*/
+
+/**
+ * Interface for pop ups
+ */
+core.Interface("unify.ui.core.IPopUp", {
+	
+	members : {
+		/**
+		 * should be used to determine what kind of popup is used.
+		 * atm we differ between 3 types : Modal, PopUp, Info
+		 * Modal is used to force the user handling the popup
+		 * PopUp is used without the forcing.
+		 * It has, however, a blocker to register events outside the PopUp.
+		 * Info should be used as a notification without any direct user interaction.
+		 * It is basically a PopUp wihtout the blocker.
+		 */
+		getPopUpType : function(){}
+	}
+});

--- a/unify/framework/source/class/unify/ui/core/IPopUp.js
+++ b/unify/framework/source/class/unify/ui/core/IPopUp.js
@@ -18,12 +18,13 @@ core.Interface("unify.ui.core.IPopUp", {
 	members : {
 		/**
 		 * should be used to determine what kind of popup is used.
-		 * atm we differ between 3 types : Modal, PopUp, Info
+		 * atm we differ between 3 types : modal, popup, info
 		 * Modal is used to force the user handling the popup
 		 * PopUp is used without the forcing.
 		 * It has, however, a blocker to register events outside the PopUp.
 		 * Info should be used as a notification without any direct user interaction.
 		 * It is basically a PopUp wihtout the blocker.
+		 * The returning value must be "info", "modal" or "popup"
 		 */
 		getPopUpType : function(){}
 	}

--- a/unify/framework/source/class/unify/ui/core/PopOverManager.js
+++ b/unify/framework/source/class/unify/ui/core/PopOverManager.js
@@ -150,7 +150,7 @@ core.Class("unify.ui.core.PopOverManager", {
 					var type;
 					//Check which interface is used atm.
 					if(visible[i].getPopUpType){
-						type = visible[i].getPopUpType().toLowerCase();
+						type = visible[i].getPopUpType();
 					} else {
 						console.warn("unify.ui.core.IPopOver is deprecated and will be replaced by unify.ui.core.IPopUp");
 						type = visible[i].getModal();

--- a/unify/framework/source/class/unify/ui/core/PopOverManager.js
+++ b/unify/framework/source/class/unify/ui/core/PopOverManager.js
@@ -147,38 +147,52 @@ core.Class("unify.ui.core.PopOverManager", {
 				var mSet=false;
 				var pSet=false;
 				for(var i=numVisible-1;i>=0;i--){
-					var modal = visible[i].getModal();
-
-					if(!mSet && modal){
+					var type;
+					//Check which interface is used atm.
+					if(visible[i].getPopUpType){
+						type = visible[i].getPopUpType().toLowerCase();
+					} else {
+						console.warn("unify.ui.core.IPopOver is deprecated and will be replaced by unify.ui.core.IPopUp");
+						type = visible[i].getModal();
+					}
+					//if type is boolean we assume the old interface is used
+					if( (!mSet && type === true) || (!mSet && type === "modal") ){
 						var styleState = visible[i].getUserData("blockerState");
 						if (styleState) {
 							var val = styleState;
 							styleState = {};
 							styleState[val] = true;
 						}
-						
 						var style = unify.theme.Manager.get().resolveStyle("MODAL-BLOCKER") || {};
 						style.zIndex = (zIndexBase-1)+2*i;
 						style.display = 'block';
-            
 						lowland.bom.Style.set(mblocker, style);
-						
 						mSet = true;
-					} else if (!pSet && !modal){
+
+					} else if ( (!pSet && type === false) || (!pSet && type === "popup")){
 						var styleState = visible[i].getUserData("blockerState");
 						if (styleState) {
 							var val = styleState;
 							styleState = {};
 							styleState[val] = true;
 						}
-						
 						var style = unify.theme.Manager.get().resolveStyle("POPOVER-BLOCKER") || {};
 						style.zIndex = (zIndexBase-1)+2*i;
 						style.display = 'block';
 						lowland.bom.Style.set(pblocker, style);
-						
+						pSet = true;
+
+					//The info popup has no blocker element
+					} else if(!pSet && type === "info"){
+						var styleState = visible[i].getUserData("blockerState");
+						if (styleState) {
+							var val = styleState;
+							styleState = {};
+							styleState[val] = true;
+						}
 						pSet = true;
 					}
+
 					if (mSet&&pSet) {
 						break;
 					}
@@ -233,6 +247,7 @@ core.Class("unify.ui.core.PopOverManager", {
 		show : function(widget, position) {
 			if (jasy.Env.getValue("debug")) {
 				this.debug("Show: " + (widget&&widget.constructor));
+				//should be switched to IPopUp in the future
 				core.Interface.assert(widget, unify.ui.core.IPopOver);
 			}
 			var pos = position || "center";


### PR DESCRIPTION
The PopOverManager had support for 2 types of popups : "Modal" and "PopUp". Both had a blocker Element which was used to prevent user action or to determine action outside the popup. With this pull request we added support for a third kind of popup : "Info".
The Info popup has no blocker element and it should not prevent user interaction.
