### PR TITLE
fix check for engine not for version IE

### DIFF
--- a/unify/framework/source/class/unify/bom/Color.js
+++ b/unify/framework/source/class/unify/bom/Color.js
@@ -22,8 +22,8 @@
 	var colorFnt;
 	
 	if (jasy.Env.getValue("engine") == "trident") {
-		var version = /MSIE.(\d+)/.exec(navigator.userAgent);
-		if (version[1] && parseInt(version[1],10) < 9) {
+	    var version = /Trident.(\d+)/.exec(navigator.userAgent);
+	    if (version[1] && parseInt(version[1], 10) < 6) {
 			colorFnt = rgb;
 		} else {
 			colorFnt = rgba;

--- a/unify/framework/source/class/unify/bom/Gradient.js
+++ b/unify/framework/source/class/unify/bom/Gradient.js
@@ -217,8 +217,8 @@ core.Module('unify.bom.Gradient', {
 			gradient = "-o-linear-gradient(" + geckoAngle + "deg, " + colorStops.join(",") + ")";
 		}
 		if (jasy.Env.getValue("engine") == "trident") {
-			var version = /MSIE.(\d+)/.exec(navigator.userAgent);
-			if (version[1] && parseInt(version[1],10) < 9) {
+		    var version = /Trident.(\d+)/.exec(navigator.userAgent);
+		    if (version[1] && parseInt(version[1], 10) < 6) {
 				return null;
 			}
 			var geckoAngle = 90 - angle;

--- a/unify/framework/source/class/unify/ui/core/EventHandler.js
+++ b/unify/framework/source/class/unify/ui/core/EventHandler.js
@@ -19,8 +19,8 @@
 	var leftMouseButton;
 	
 	if (jasy.Env.getValue("engine") == "trident") {
-		var version = /MSIE.(\d+)/.exec(navigator.userAgent);
-		if (version[1] && parseInt(version[1],10) < 9) {
+	    var version = /Trident.(\d+)/.exec(navigator.userAgent);
+	    if (version[1] && parseInt(version[1], 10) < 6) {
 			leftMouseButton = 1;
 		} else {
 			leftMouseButton = 0;

--- a/unify/framework/source/class/unify/ui/core/Widget.js
+++ b/unify/framework/source/class/unify/ui/core/Widget.js
@@ -1603,8 +1603,8 @@ core.Class("unify.ui.core.Widget", {
 			}*/
 			
 			if (jasy.Env.getValue("engine") == "trident") {
-				var version = /MSIE.(\d+)/.exec(navigator.userAgent);
-				if (version[1] && parseInt(version[1],10) < 9) {
+				var version = /Trident.(\d+)/.exec(navigator.userAgent);
+				if (version[1] && parseInt(version[1],10) < 6) {
 					// IE<9 only transform translation
 					
 					if (style.transform) {


### PR DESCRIPTION
Internet Explorer 11 is released, yay.  Microsoft changed the User-Agent string, browser check failed -> null pointer. 

This fix should enable the IE 11 support for unify and solve the problem by checking for the engine version not for the browser version.
